### PR TITLE
Use date objects instead of numbers to represent dates

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -23,14 +23,14 @@ Job.prototype.save = function(callback) {
 
 Job.prototype.complete = function(result, callback) {
     this.data.status = 'complete';
-    this.data.ended = Date.now();
+    this.data.ended = new Date();
     this.data.result = result;
     this.save(callback);
 };
 
 Job.prototype.fail = function(error, callback) {
     this.data.status = 'failed';
-    this.data.ended = Date.now();
+    this.data.ended = new Date();
     this.data.error = error.message;
     this.save(callback);
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -28,7 +28,7 @@ Queue.prototype.enqueue = function(name, params, callback) {
         params: params,
         queue: this.name,
         status: 'queued',
-        enqueued: Date.now()
+        enqueued: new Date()
     });
 
     job.save(callback);
@@ -39,7 +39,7 @@ Queue.prototype.dequeue = function(callback) {
     
     var query = { status: 'queued', queue: this.name };
     var sort = { enqueued: 1 };
-    var update = { '$set': { status: 'dequeued', dequeued: Date.now() }};
+    var update = { '$set': { status: 'dequeued', dequeued: new Date() }};
     var options = { new: true };
 
     this.collection.findAndModify(query, sort, update, options, function(err, doc) {

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -76,7 +76,7 @@ describe('Job', function() {
         });
 
         it('has an end time', function() {
-            assert.ok(job.data.ended <= Date.now());
+            assert.ok(job.data.ended <= new Date());
         });
 
         it('has a result', function() {
@@ -98,7 +98,7 @@ describe('Job', function() {
 
         it('has an end time', function() {
             assert.ok(job.data.ended);
-            assert.ok(job.data.ended <= Date.now());
+            assert.ok(job.data.ended <= new Date());
         });
 
         it('has an error', function() {

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -39,7 +39,7 @@ describe('queue', function() {
 
         it('has an enqueued date', function() {
             assert.ok(job.data.enqueued);
-            assert.ok(job.data.enqueued <= Date.now());
+            assert.ok(job.data.enqueued <= new Date());
         });
 
         it('has `queued` status', function() {
@@ -76,7 +76,7 @@ describe('queue', function() {
 
         it('has a dequeued date', function() {
             assert.ok(job.data.dequeued);
-            assert.ok(job.data.dequeued <= Date.now());
+            assert.ok(job.data.dequeued <= new Date());
         });
 
         it('has `dequeued` status', function() {


### PR DESCRIPTION
I'm not sure if you had a specific reason for using numbers to represent dates in mongo, but for my use case I definitely want real date objects. Just thought I'd send this upstream to see if you were interested or not. No worries if not.
