### PR TITLE
Cancel the poll timeout so the worker will stop more quickly

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -54,8 +54,14 @@ Worker.prototype.stop = function (callback) {
     }
 
     if (!this.working) done();
-
     this.working = false;
+
+    if(this.pollTimeout) {
+      clearTimeout(this.pollTimeout);
+      this.pollTimeout = null;
+      return done();
+    }
+
     this.once('stopped', done);
 };
 
@@ -82,7 +88,8 @@ Worker.prototype.poll = function () {
 
             if (self.empty === self.queues.length) {
                 // All queues are empty, wait a bit
-                setTimeout(function () {
+                self.pollTimeout = setTimeout(function () {
+                    self.pollTimeout = null;
                     self.poll();
                 }, self.interval);
             } else {

--- a/test/test_worker.js
+++ b/test/test_worker.js
@@ -116,8 +116,8 @@ describe('Worker', function () {
                 worker.start();
 
                 var poll = sinon.spy(worker, 'poll');
-                worker.stop();
                 clock.tick(worker.interval);
+                worker.stop();
 
                 assert.ok(poll.calledOnce);
             });


### PR DESCRIPTION
I was having a funny issue where the setTimeout in the woker.poll never triggered (I think due to mocking the clock with sinon).

I switched the stop method to cancel the poll immediately, which also has a benefit of stopping the service more quickly for jobs on long poll intervals.
