### PR TITLE
adding ordination as option

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -12,6 +12,7 @@ function Queue(connection, name, options) {
 
     options || (options = {});
     options.collection || (options.collection = 'jobs');
+    options.sort || (options.sort = [['priority', 'desc'], ['_id', 'asc']]);
 
     this.connection = connection;
     this.name = name || 'default';
@@ -85,7 +86,7 @@ Queue.prototype.dequeue = function (options, callback) {
         query.name = { $in: callback_names };
     }
 
-    var sort = [['priority', 'desc'], ['_id', 'asc']];
+    var sort = options.sort || this.options;
     var update = { $set: { status: Job.DEQUEUED, dequeued: new Date() }};
     var options = { new: true };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -86,7 +86,7 @@ Queue.prototype.dequeue = function (options, callback) {
         query.name = { $in: callback_names };
     }
 
-    var sort = options.sort || this.options;
+    var sort = options.sort || this.options.sort;
     var update = { $set: { status: Job.DEQUEUED, dequeued: new Date() }};
     var options = { new: true };
 


### PR DESCRIPTION
Hello ... First thank you for Developing the "monq"!

Now I will try to explain the problem that caused me to develop this "pull-request".

I have a task in the "worker" which is very simple and runs very fast, but I have to climb the worker to have many processors simultaneously.

When climb these "worker" and they try to get tasks at the same time, some can not get any job because "findAndModify" returns only the first one asked. The result is that even if 30 "workers" ready to work only one of them is working and they alternate each other, but only one at a time works.

See example:

``` javascript
'use strict';

var monq = require('monq');

var client = monq('mongodb://admin@mongo:27017/myqueue/?', {
  server: {
    auto_reconnect: true,
    // define poolSize 10 to simulate the concurrency
    poolSize: 10
  }
});

client.db.collection('jobs', function (err, collection) {
  if (err) {
    console.error(err);
  } else {
    // Loop 10 times to simulate the concurrency
    for (var i = 0; i < 10; i++) {
      collection.findAndModify({
        status: 'queued',
        queue: 'mysqueue',
        delay: {$lte: new Date()}
      }, [['priority', 'desc'], ['_id', 'asc']], {
        $set: {
          status: 'dequeued',
          dequeued: new Date()
        }
      }, {new: true}, function (err, doc, other) {
        if (err) {
          console.err(err);
        } else if(doc){
          console.log(doc);
        }else{
          console.log(other);
        }
      });
    }
  }
});
```

If you withdraw the order ([['priority', 'desc'], ['_id', 'asc']]) of "query", the mongo then proceeds to answer to everyone.
So this "pull-request" makes it possible to specify the sort of way you prefer.

(Sorry, my english is not good!)