### PR TITLE
Migrate to mongojs to avoid peerDependency hell

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,4 +1,4 @@
-var mongo = require('mongoskin');
+var mongo = require('mongojs');
 var job = require('./job');
 var Queue = require('./queue');
 var Worker = require('./worker');
@@ -6,7 +6,7 @@ var Worker = require('./worker');
 module.exports = Connection;
 
 function Connection(uri, options) {
-    this.db = mongo.db(uri, options);
+    this.db = mongo(uri, [], options);
 }
 
 Connection.prototype.worker = function (queues, options) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,29 +1,21 @@
 exports.index = function (collection) {
-    // Drop old indexes
+    collection.getIndexes(function(err, indexes) {
+        if (err) { return console.log(err); }
 
-    collection.indexExists('status_1_queue_1_enqueued_1', function (err, indexes) {
-        if (err) console.error(err);
+        dropIndex('status_1_queue_1_enqueued_1');
+        dropIndex('status_1_queue_1_enqueued_1_delay_1');
 
-        if (indexes === true) {
-            collection.dropIndex('status_1_queue_1_enqueued_1', function (err, result) {
-                if (err) console.error(err);
-            });
-        }
-    });
-
-    collection.indexExists('status_1_queue_1_enqueued_1_delay_1', function (err, indexes) {
-        if (err) console.error(err);
-
-        if (indexes === true) {
-            collection.dropIndex('status_1_queue_1_enqueued_1_delay_1', function (err, result) {
-                if (err) console.error(err);
-            });
+        function dropIndex(name) {
+            if (indexes.some(function(index) { return index.name == name; })) {
+                collection.dropIndex(name, function(err) {
+                    if (err) { console.error(err); }
+                });
+            }
         }
     });
 
     // Ensures there's a reasonable index for the poling dequeue
     // Status is first b/c querying by status = queued should be very selective
-
     collection.ensureIndex({ status: 1, queue: 1, priority: 1, _id: 1, delay: 1 }, function (err) {
         if (err) console.error(err);
     });

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,5 +1,4 @@
 var events = require('events');
-var mongoskin = require('mongoskin');
 var util = require('util');
 
 module.exports = Job;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,4 +1,4 @@
-var mongoskin = require('mongoskin');
+var mongo = require('mongojs');
 var db = require('./db');
 var Job = require('./job');
 
@@ -33,7 +33,7 @@ Queue.prototype.get = function (id, callback) {
     var self = this;
 
     if (typeof id === 'string') {
-        id = new mongoskin.helper.toObjectID(id);
+        id = new mongo.ObjectID(id);
     }
 
     var query = { _id: id };
@@ -94,15 +94,23 @@ Queue.prototype.dequeue = function (options, callback) {
         query.name = { $in: callback_names };
     }
 
-    var sort = [['priority', 'desc'], ['_id', 'asc']];
+    var sort = {
+        'priority': -1,
+        '_id': 1
+    };
+
     var update = { $set: { status: Job.DEQUEUED, dequeued: new Date() }};
-    var options = { new: true };
 
-    this.collection.findAndModify(query, sort, update, options, function (err, doc) {
+    this.collection.findAndModify({
+        query: query,
+        sort: sort,
+        update: update,
+        new: true
+    }, function (err, doc) {
         if (err) return callback(err);
-        if (!doc || !doc.value) return callback();
+        if (!doc) return callback();
 
-        callback(null, self.job(doc.value));
+        callback(null, self.job(doc));
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "url": "git://github.com/scttnlsn/monq.git"
   },
   "dependencies": {
-    "mongodb": "~2.0.44",
-    "mongoskin": "^2.0.0"
+    "mongojs": "^2.1.0"
   },
   "devDependencies": {
     "async": "^1.5.0",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,9 +1,9 @@
 var async = require('async');
-var mongo = require('mongoskin');
+var mongo = require('mongojs');
 
 exports.uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/monq_tests';
 
-exports.db = mongo.db(exports.uri, { safe: true });
+exports.db = mongo(exports.uri, [], { safe: true });
 
 exports.each = function (fixture, fn, done) {
     async.each(fixture, function (args, callback) {

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -32,7 +32,7 @@ describe('Job', function () {
         });
 
         it('is inserted into collection', function (done) {
-            collection.findById(job.data._id, function (err, doc) {
+            collection.findOne({ _id : job.data._id }, function (err, doc) {
                 if (err) return done(err);
 
                 assert.ok(doc);
@@ -43,7 +43,7 @@ describe('Job', function () {
         });
 
         it('contains a string id', function (done) {
-            collection.findById(job.data._id, function (err, doc) {
+            collection.findOne({ _id : job.data._id }, function (err, doc) {
                 if (err) return done(err);
 
                 assert.equal(doc._id.toString(), job.data.id);


### PR DESCRIPTION
Since mongoskin uses peer dependencies for the mongodb driver this will "drive" every larger project using more than one mongoskin version into peer dependency hell. This version mitigates that issue by using mongojs under the hood which does include mongodb connection management but does not use peerDependencies.