### PR TITLE
Added support for specifying collection name for client

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -5,17 +5,18 @@ var Worker = require('./worker');
 
 module.exports = Connection;
 
-function Connection(uri, options) {
+function Connection(uri, options, collectionParameters) {
     this.db = mongo(uri, [], options);
+    this.collectionParameters = (collectionParameters || {});
 }
 
 Connection.prototype.worker = function (queues, options) {
     var self = this;
 
     if (queues === "*") {
-        var opts = {universal: true, collection: options.collection || 'jobs' };
+        var opts = {universal: true, collection: this.collectionParameters.name || 'jobs' };
         options.universal = true;
-        queues = [new Queue('*', opts)];
+        queues = [new Queue('*', opts, this.collectionName)];
     } else {
         if (!Array.isArray(queues)) {
             queues = [queues];
@@ -33,7 +34,7 @@ Connection.prototype.worker = function (queues, options) {
 };
 
 Connection.prototype.queue = function (name, options) {
-    return new Queue(this, name, options);
+    return new Queue(this, name, options, this.collectionParameters.name || 'jobs');
 };
 
 Connection.prototype.close = function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var Connection = require('./connection');
 
-module.exports = function (uri, options) {
-    return new Connection(uri, options);
+module.exports = function (uri, options, collectionParameters) {
+    return new Connection(uri, options, collectionParameters);
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -4,14 +4,15 @@ var Job = require('./job');
 
 module.exports = Queue;
 
-function Queue(connection, name, options) {
-    if (typeof name === 'object' && options === undefined) {
+function Queue(connection, name, options, collectionName) {
+    if (typeof name === 'object' && collectionName === undefined) {
+        collectionName = options;
         options = name;
         name = undefined;
     }
 
     options || (options = {});
-    options.collection || (options.collection = 'jobs');
+    options.collection  = collectionName;
     options.universal || (options.universal = false);
 
     this.connection = connection;

--- a/test/test_priority.js
+++ b/test/test_priority.js
@@ -10,7 +10,7 @@ describe('Priority', function () {
     var handler, queue, worker;
 
     beforeEach(function () {
-        queue = new Queue({ db: helpers.db });
+        queue = new Queue({ db: helpers.db }, null, null, 'testcollection');
 
         handler = sinon.spy(function (params, callback) {
             callback();

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -6,7 +6,7 @@ describe('Queue', function () {
     var queue;
 
     beforeEach(function () {
-        queue = new Queue({ db: helpers.db });
+        queue = new Queue({ db: helpers.db }, null, null, 'testcollection');
     });
 
     afterEach(function (done) {

--- a/test/test_retries.js
+++ b/test/test_retries.js
@@ -9,7 +9,7 @@ describe('Retries', function () {
     var queue, handler, worker, failed;
 
     beforeEach(function () {
-        queue = new Queue({ db: helpers.db });
+        queue = new Queue({ db: helpers.db }, null, null, 'testcollection');
 
         handler = sinon.spy(function (params, callback) {
             return callback(new Error());

--- a/test/test_timeout.js
+++ b/test/test_timeout.js
@@ -8,7 +8,7 @@ describe('Timeout', function () {
     var queue, handler, worker, failed;
 
     beforeEach(function () {
-        queue = new Queue({ db: helpers.db });
+        queue = new Queue({ db: helpers.db }, null, null, 'testcollection');
 
         handler = sinon.spy(function (params, callback) {
             // Don't call the callback, let it timeout


### PR DESCRIPTION
This addresses issue #56 by moving where the collection name can be specified to the client/connection so that all queues and workers of that connection will use the specified collection name.

The name is not set in the options parameter, as that set of options is used by mongojs for other purposes. Instead, I've added a third parameter, 'collectionParameters'. The only valid value for that object currently is 'name'. I'm using an object here, because I'm toying with the idea of adding other collection defining variables, such as those to create a capped collection.

This is a non breaking change, and 'jobs' is still the default should you not provide a collection name to use. Below is an example using the new parameter.

`var client = monq('mongodb://localhost:27017/monq_example', [], { name: '_jobqueue' });`

