### PR TITLE
Adding some JSDoc documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,177 @@
+## Classes
+
+<dl>
+<dt><a href="#Connection">Connection</a></dt>
+<dd></dd>
+<dt><a href="#Job">Job</a></dt>
+<dd></dd>
+<dt><a href="#Worker">Worker</a></dt>
+<dd></dd>
+</dl>
+
+<a name="Connection"></a>
+
+## Connection
+**Kind**: global class  
+
+* [Connection](#Connection)
+    * [new Connection(uri, options)](#new_Connection_new)
+    * [.worker(queues, options)](#Connection+worker)
+
+<a name="new_Connection_new"></a>
+
+### new Connection(uri, options)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uri | <code>string</code> | MongoDB connection string |
+| options | <code>Object</code> | connection options |
+
+<a name="Connection+worker"></a>
+
+### connection.worker(queues, options)
+Returns a new [Worker](#Worker)
+
+**Kind**: instance method of <code>[Connection](#Connection)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| queues | <code>Array.&lt;string&gt;</code> &#124; <code>string</code> | list of queue names, a single queue name, or '*' for a universal worker |
+| options | <code>Object</code> | an object with worker options |
+
+<a name="Job"></a>
+
+## Job
+**Kind**: global class  
+
+* [Job](#Job)
+    * [new Job(collection, data)](#new_Job_new)
+    * [~Attempts](#Job..Attempts) : <code>Object</code>
+
+<a name="new_Job_new"></a>
+
+### new Job(collection, data)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| collection | <code>string</code> | The collection to save the job to |
+| data | <code>Object</code> | The Job data |
+
+<a name="Job..Attempts"></a>
+
+### Job~Attempts : <code>Object</code>
+Job retry specification
+
+**Kind**: inner typedef of <code>[Job](#Job)</code>  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| strategy | <code>string</code> | Name of [Worker~strategyCallback](Worker~strategyCallback) to use on retry |
+| count | <code>number</code> | total number of attempts so far |
+| delay | <code>number</code> | a delay constant for use in determining a delay.  In default linear strategy, this will be the delay between attempts |
+
+<a name="Worker"></a>
+
+## Worker
+**Kind**: global class  
+
+* [Worker](#Worker)
+    * [new Worker(queues, options)](#new_Worker_new)
+    * _instance_
+        * [.register(callbacks)](#Worker+register)
+        * [.start()](#Worker+start)
+        * [.stop()](#Worker+stop)
+        * [.addQueue(queue)](#Worker+addQueue)
+    * _inner_
+        * [~Options](#Worker..Options) : <code>Object</code>
+        * [~Callback](#Worker..Callback) : <code>function</code>
+        * [~Strategies](#Worker..Strategies) : <code>Object</code>
+        * [~StrategyCallback](#Worker..StrategyCallback) ⇒ <code>Number</code>
+
+<a name="new_Worker_new"></a>
+
+### new Worker(queues, options)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| queues | <code>Array.&lt;string&gt;</code> | an array of queue names that this worker will listen for |
+| options | <code>[Options](#Worker..Options)</code> | [Options](#Worker..Options) Options object |
+
+<a name="Worker+register"></a>
+
+### worker.register(callbacks)
+Sets handlers to be invoked for each queue that the worker is listening to
+
+**Kind**: instance method of <code>[Worker](#Worker)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| callbacks | <code>Object</code> | map of [Callback](#Worker..Callback) objects. Keys are the name of the queue, values are the handlers for those queues |
+
+<a name="Worker+start"></a>
+
+### worker.start()
+Starts the worker.  If no queues have been specified yet, this will loop
+
+**Kind**: instance method of <code>[Worker](#Worker)</code>  
+<a name="Worker+stop"></a>
+
+### worker.stop()
+Stops the worker
+
+**Kind**: instance method of <code>[Worker](#Worker)</code>  
+<a name="Worker+addQueue"></a>
+
+### worker.addQueue(queue)
+Adds a queue for the worker to listen on
+
+**Kind**: instance method of <code>[Worker](#Worker)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| queue | <code>string</code> | the name of the queue to add |
+
+<a name="Worker..Options"></a>
+
+### Worker~Options : <code>Object</code>
+Options for a new worker
+
+**Kind**: inner typedef of <code>[Worker](#Worker)</code>  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| interval | <code>Number</code> | the polling interval for the worker. Note: The worker will process jobs, one at a time, as fast as possible while queues have waiting jobs |
+| strategies | <code>[Strategies](#Worker..Strategies)</code> | [Strategies](#Worker..Strategies) for retrying jobs |
+| callbacks | <code>Worker~Callbacks</code> | Map of [Callback](#Worker..Callback) for processing jobs |
+| minPriority | <code>Number</code> | The lowest job priority the worker will process |
+
+<a name="Worker..Callback"></a>
+
+### Worker~Callback : <code>function</code>
+Job handler functions should take this form
+
+**Kind**: inner typedef of <code>[Worker](#Worker)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| params | <code>Job.params</code> | [Job.params](Job.params) object for the job to be processed |
+| callback | <code>function</code> | NodeJS style callback to be invoked when job processing is finished |
+
+<a name="Worker..Strategies"></a>
+
+### Worker~Strategies : <code>Object</code>
+A map of [StrategyCallback](#Worker..StrategyCallback)s
+
+**Kind**: inner typedef of <code>[Worker](#Worker)</code>  
+<a name="Worker..StrategyCallback"></a>
+
+### Worker~StrategyCallback ⇒ <code>Number</code>
+**Kind**: inner typedef of <code>[Worker](#Worker)</code>  
+**Returns**: <code>Number</code> - delay time  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| attempts | <code>[Attempts](#Job..Attempts)</code> | [Attempts](#Job..Attempts) object |
+

--- a/README.md
+++ b/README.md
@@ -72,3 +72,8 @@ Tests
 You can optionally specify the MongoDB URI to be used for tests:
 
     MONGODB_URI=mongodb://localhost:27017/monq_tests npm test
+
+Updating API documentation
+--------------------------
+
+`npm run jsdoc2md`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Monq is a MongoDB-backed job queue for Node.js.
 [![NPM](https://img.shields.io/npm/v/monq.svg?style=flat)](http://npm.im/monq)
 [![Build Status](https://img.shields.io/travis/scttnlsn/monq.svg?style=flat)](https://travis-ci.org/scttnlsn/monq)
 
+[API Reference](API.md)
+
 Usage
 -----
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -5,7 +5,6 @@ var Worker = require('./worker');
 
 module.exports = Connection;
 
-
 /**
 * @constructor
 * @param {string} uri - MongoDB connection string

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -5,10 +5,21 @@ var Worker = require('./worker');
 
 module.exports = Connection;
 
+
+/**
+* @constructor
+* @param {string} uri - MongoDB connection string
+* @param {Object} options - connection options
+*/
 function Connection(uri, options) {
     this.db = mongo(uri, [], options);
 }
 
+/**
+* Returns a new {@link Worker}
+* @param {string[]|string} queues - list of queue names, a single queue name, or '*' for a universal worker
+* @param {Object} options - an object with worker options
+*/
 Connection.prototype.worker = function (queues, options) {
     var self = this;
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -3,6 +3,19 @@ var util = require('util');
 
 module.exports = Job;
 
+/**
+* Job retry specification
+* @typedef {Object} Job~Attempts
+* @property {string} strategy - Name of {@link Worker~strategyCallback} to use on retry
+* @property {number} count - total number of attempts so far
+* @property {number} delay - a delay constant for use in determining a delay.  In default linear strategy, this will be the delay between attempts
+*/
+
+/**
+* @constructor
+* @param {string} collection - The collection to save the job to
+* @param {Object} data - The Job data
+*/
 function Job(collection, data) {
     this.collection = collection;
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -121,7 +121,6 @@ function parseTimeout(timeout) {
     return parseInt(timeout, 10);
 }
 
-
 function parseAttempts(attempts) {
     if (attempts === undefined) return undefined;
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -121,6 +121,7 @@ function parseTimeout(timeout) {
     return parseInt(timeout, 10);
 }
 
+
 function parseAttempts(attempts) {
     if (attempts === undefined) return undefined;
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -241,8 +241,6 @@ Worker.prototype.error = function (job, err, callback) {
 // Strategies
 // ---------------
 
-
-
 function linear(attempts) {
     return attempts.delay;
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -4,6 +4,20 @@ var Queue = require('./queue');
 
 module.exports = Worker;
 
+/**
+* Options for a new worker
+* @typedef {Object} Worker~Options
+* @property {Number} interval - the polling interval for the worker. Note: The worker will process jobs, one at a time, as fast as possible while queues have waiting jobs
+* @property {Worker~Strategies} strategies - {@link Worker~Strategies} for retrying jobs
+* @property {Worker~Callbacks} callbacks - Map of {@link Worker~Callback} for processing jobs
+* @property {Number} minPriority - The lowest job priority the worker will process
+*/
+
+/**
+* @constructor
+* @param {string[]} queues - an array of queue names that this worker will listen for
+* @param {Worker~Options} options - {@link Worker~Options} Options object 
+*/
 function Worker(queues, options) {
     options || (options = {});
 
@@ -26,11 +40,33 @@ function Worker(queues, options) {
 
 util.inherits(Worker, events.EventEmitter);
 
+/**
+* Job handler functions should take this form
+* @callback Worker~Callback
+* @param {Job.params} params - {@link Job.params} object for the job to be processed 
+* @param {Function} callback - NodeJS style callback to be invoked when job processing is finished
+*/
+
+/**
+* Sets handlers to be invoked for each queue that the worker is listening to
+* @param {Object} callbacks - map of {@link Worker~Callback} objects. Keys are the name of the queue, values are the handlers for those queues
+*/
 Worker.prototype.register = function (callbacks) {
     for (var name in callbacks) {
         this.callbacks[name] = callbacks[name];
     }
 };
+
+/**
+* A map of {@link Worker~StrategyCallback}s
+* @typedef {Object} Worker~Strategies
+*/
+
+/**
+* @callback Worker~StrategyCallback
+* @param {Job~Attempts} attempts - {@link Job~Attempts} object
+* @returns {Number} delay time
+*/
 
 Worker.prototype.strategies = function (strategies) {
     for (var name in strategies) {
@@ -38,6 +74,10 @@ Worker.prototype.strategies = function (strategies) {
     }
 };
 
+
+/**
+* Starts the worker.  If no queues have been specified yet, this will loop
+*/
 Worker.prototype.start = function () {
     if (this.queues.length === 0) {
         return setTimeout(this.start.bind(this), this.interval);
@@ -46,6 +86,9 @@ Worker.prototype.start = function () {
     this.poll();
 };
 
+/**
+* Stops the worker
+*/
 Worker.prototype.stop = function (callback) {
     var self = this;
 
@@ -65,6 +108,10 @@ Worker.prototype.stop = function (callback) {
     this.once('stopped', done);
 };
 
+/**
+* Adds a queue for the worker to listen on
+* @param {string} queue - the name of the queue to add
+*/
 Worker.prototype.addQueue = function (queue) {
   if (!this.universal)
     this.queues.push(queue);
@@ -193,6 +240,8 @@ Worker.prototype.error = function (job, err, callback) {
 
 // Strategies
 // ---------------
+
+
 
 function linear(attempts) {
     return attempts.delay;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "main": "./lib/index",
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "./node_modules/.bin/mocha",
+    "jsdoc2md" : "jsdoc2md lib/*.js > API.md"
   },
   "repository": {
     "type": "git",
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "async": "^1.5.0",
+    "jsdoc-to-markdown": "^2.0.1",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2"
   }


### PR DESCRIPTION
I've been working with this library for a little while, and the lack of documentation for some features was holding me back, so I decided to add some.  Hopefully it will be able to speedup adoption for others.

I used JSDoc formatting, and included the first run of [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown) output as API.md