### PR TITLE
BUG (broken) v0.3.4->v0.3.5 | mongo connect

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -20,27 +20,35 @@ function Connection(uri, options) {
 * @param {Object} options - an object with worker options
 */
 Connection.prototype.worker = function (queues, options) {
-    var self = this,
-        opts;
+    var self = this;
+
+    options || (options = {});
+
+    var collection = options.collection || 'jobs';
 
     if (queues === "*") {
-        opts = {universal: true, collection: options.collection || 'jobs' };
         options.universal = true;
-        queues = [self.queue('*', opts)];
+
+        queues = [self.queue('*', {
+          universal: true,
+          collection: collection
+        })];
     } else {
         if (!Array.isArray(queues)) {
             queues = [queues];
         }
 
-        opts = {collection: options.collection || 'jobs' };
         var queues = queues.map(function (queue) {
             if (typeof queue === 'string') {
-                queue = self.queue(queue, opts);
+                queue = self.queue(queue, {
+                  collection: collection
+                });
             }
 
             return queue;
         });
     }
+
     return new Worker(queues, options);
 };
 


### PR DESCRIPTION
Env:

- NodeJS: v6.7
- Mongo: v3.0
- Monq: 0.3.5

Code (working on v0.3.4):
`monq(mongoURL)`

Error (exception):
`
TypeError: Cannot read property 'collection' of undefined
    at Connection.worker (/home/ubuntu/___/node_modules/monq/lib/connection.js:35:36)
`