### PR TITLE
Switch sort direction of index in order to improve performance

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -22,7 +22,7 @@ exports.index = function (collection) {
 
     // Ensures there's a reasonable index for the poling dequeue
     // Status is first b/c querying by status = queued should be very selective
-    collection.ensureIndex({ status: 1, queue: 1, priority: 1, _id: 1, delay: 1 }, function (err) {
+    collection.ensureIndex({ status: 1, queue: 1, priority: -1, _id: 1, delay: 1 }, function (err) {
         if (err) console.error(err);
     });
 };


### PR DESCRIPTION
This significantly increases the performance of the queue because the result set when dequeueing doesn't need to be sorted anymore.

See queue.js:97:

`
    var sort = {
        'priority': -1,
        '_id': 1
    };
`